### PR TITLE
Add clickDismissEnabled option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ snackbars.createNotification({
     bgColor: 'purple',
 
     // the color of the notification's message (defaults to white)
-    messageColor: 'white'
+    messageColor: 'white',
+
+    // the notification will not be dismissed from clicking on it (defaults to true)
+    clickDismissEnabled: false,
 
     // the buttons to render on the snackbar (optional)
     buttons: [

--- a/demo/pages/home/main.js
+++ b/demo/pages/home/main.js
@@ -1,8 +1,9 @@
 var count = 1;
+var clickDismissCount = 1;
 var dogeCount = 0;
 var generateNumberedSnackBtn = document.getElementById('simple-notification-btn');
 var generateDogeSnackBtn = document.getElementById('doge-notification-btn');
-var dismissableSnackBtn = document.getElementById('dismissable-notification-btn');
+var clickDismissEnabledSnackBtn = document.getElementById('click-dismiss-enabled-notification-btn');
 
 var markoSnackbars = window.markoSnackbars;
 
@@ -59,22 +60,17 @@ generateNumberedSnackBtn.addEventListener('click', function() {
     count++;
 });
 
+clickDismissEnabledSnackBtn.addEventListener('click', function() {
+    markoSnackbars.createNotification({
+        position: 'tr',
+        message: 'Click Dismiss Notification ' + clickDismissCount,
+        clickDismissEnabled: false
+    });
+    clickDismissCount++;
+});
+
 generateDogeSnackBtn.addEventListener('click', function() {
     var notification = dogeNotifications[dogeCount % dogeNotifications.length];
     markoSnackbars.createNotification(notification);
     dogeCount++;
-});
-
-dismissableSnackBtn.addEventListener('click', function() {
-    markoSnackbars.createNotification({
-        message: 'Dismiss this',
-        denyText: 'Dismiss',
-        onDeny: function() {
-            markoSnackbars.createNotification({
-                message: 'Notification was dismissed!',
-                bgColor: 'red'
-            });
-        },
-        ttl: -1
-    });
 });

--- a/demo/pages/home/template.marko
+++ b/demo/pages/home/template.marko
@@ -7,5 +7,5 @@ html
     body
         button id='simple-notification-btn' - Generate Simple Notification
         button id='doge-notification-btn' - Generate Doge Notification
-        button id='dismissable-notification-btn' - Generate Dismissable Notification
+        button id='click-dismiss-enabled-notification-btn' - Generate a non-click-dismiss button
         lasso-body

--- a/src/components/snackbar/index.js
+++ b/src/components/snackbar/index.js
@@ -53,6 +53,10 @@ module.exports = require('marko-widgets').defineComponent({
      * @param {string} input.dismissText
      */
     getInitialState: function(input) {
+        var clickDismissEnabled = typeof input.clickDismissEnabled !== 'undefined' ?
+            input.clickDismissEnabled :
+            true;
+
         return {
             message: input.message,
             transitionDirection: input.transitionDirection,
@@ -60,6 +64,7 @@ module.exports = require('marko-widgets').defineComponent({
             persist: input.persist,
             bgColor: input.bgColor,
             messageColor: input.messageColor,
+            clickDismissEnabled: clickDismissEnabled,
 
             // array of buttons to render
             // example format for a button:
@@ -68,9 +73,9 @@ module.exports = require('marko-widgets').defineComponent({
         };
     },
 
-    handleButtonClick(event, buttonEl) {
+    handleButtonClick: function(event, buttonEl) {
         var pos = buttonEl.getAttribute('data-pos');
-        let onClick = this.state.buttons[pos].onClick;
+        var onClick = this.state.buttons[pos].onClick;
 
         if (onClick) {
             onClick();
@@ -80,18 +85,8 @@ module.exports = require('marko-widgets').defineComponent({
         _preventEventBubbling(event);
     },
 
-    handleDeny: function(event) {
-        if (this.onDeny) {
-            this.onDeny();
-        }
-
-        _handleRemove(this);
-        event.preventDefault();
-    },
-
     handleClick: function(event) {
-        // dismiss notification onAllow or onDeny is not provided
-        if (!this.onDeny && !this.onAllow) {
+        if (this.state.clickDismissEnabled) {
             _handleRemove(this);
         }
 


### PR DESCRIPTION
There may be a circumstance where we do not want the user to be able to dismiss the notification by simply clicking on it. For example, we may want to force them to select a button in the notification.